### PR TITLE
Fix: replace failing on "/" character.

### DIFF
--- a/customizepkg
+++ b/customizepkg
@@ -65,9 +65,9 @@ modify_file()
 					pattern="$pattern[<>=]*[a-z0-9.]*"
 				fi
 				if [ "$context" = "global" ]; then
-					sed -i "s/$pattern/$value/g" "$scriptfile"
+					sed -i "s$pattern$valueg" "$scriptfile"
 				else
-					sed -i "/^$context=/,/)$/ s/[[:space:]]*[']*$pattern[']*/$value/g" "$scriptfile"
+					sed -i "/^$context=/,/)$/ s[[:space:]]*[']*$pattern[']*$valueg" "$scriptfile"
 				fi
 				;;
 			add)
@@ -75,9 +75,9 @@ modify_file()
 				echo "=> adds $value in $context"
 				# add the full line if it doesn't exist or just the value
 				if grep --quiet "^$context=" "$scriptfile"; then
-					sed -i "s/^$context=(/&$value /1" "$scriptfile"
+					sed -i "s^$context=(&$value 1" "$scriptfile"
 				else
-					sed -i "/^build/i$context=($value)\n" "$scriptfile"
+					sed -i "^buildi$context=($value)\n" "$scriptfile"
 				fi
 				;;
 			*)
@@ -85,8 +85,8 @@ modify_file()
 				;;
 		esac
 	done
-	[ $VIMDIFF -eq 1 ] && vim -d "$scriptfile" "$originalscriptfile"	
-	diff -Naur "$originalscriptfile" "$scriptfile"	
+	[ $VIMDIFF -eq 1 ] && vim -d "$scriptfile" "$originalscriptfile"
+	diff -Naur "$originalscriptfile" "$scriptfile"
 	return 0
 }
 


### PR DESCRIPTION
Because this is being used in the sed command as the delimiter. Instead, use an ASCII control code in the assumption that no one else will ever be using that. Alternatively, something like "@" could be used, but that one at least seems to be a fairly common alternative, and won't be proof against further clashes...

So far it's been working for me. :)
